### PR TITLE
Support module name that includes hyphen

### DIFF
--- a/lib/compose_compiler_metrics/helper.rb
+++ b/lib/compose_compiler_metrics/helper.rb
@@ -3,7 +3,14 @@
 module Helper
   def build_variants(dir)
     Dir.glob("#{dir}/*").
-      map { |s| File.basename(s).split(/[_-]/).take(2) }.
+      map do |s|
+        filename = File.basename(s)
+
+        [
+          filename.split("_").first, # module_name
+          filename[(filename.index("_") + 1)...filename.rindex("-")] # build_variants_name
+        ]
+      end.
       uniq
   end
 

--- a/lib/compose_compiler_metrics/plugin.rb
+++ b/lib/compose_compiler_metrics/plugin.rb
@@ -10,14 +10,16 @@ module Danger
   class DangerComposeCompilerMetrics < Plugin
     include Helper
 
-    def report_difference(metrics_dir, reference_metrics_dir, options = {})
+    def report_difference(metrics_dir, reference_metrics_dir, options = {}, build_variant_names = nil)
       unless installed?("diff")
         failure "diff command not found. Please install diff command."
         return
       end
 
+      build_variant_names ||= build_variants(metrics_dir)
+
       markdown("# Compose Compiler Metrics Difference Report")
-      build_variants(metrics_dir).each do |module_name, build_variant|
+      build_variant_names.each do |module_name, build_variant|
         markdown("## #{module_name} - #{build_variant}")
 
         # Metrics Report

--- a/spec/compose_compiler_metrics_spec.rb
+++ b/spec/compose_compiler_metrics_spec.rb
@@ -343,7 +343,7 @@ describe Danger::DangerComposeCompilerMetrics do
             "DangerComposeCompilerMetrics: new file not found at #{File.dirname(__FILE__)}/support/fixtures/compose_compiler_metrics/app_release-module.json. Skipping file difference report.",
             "DangerComposeCompilerMetrics: new file not found at #{File.dirname(__FILE__)}/support/fixtures/compose_compiler_metrics/app_release-composables.csv. Skipping file difference report.",
             "DangerComposeCompilerMetrics: new file not found at #{File.dirname(__FILE__)}/support/fixtures/compose_compiler_metrics/app_release-composables.txt. Skipping file difference report.",
-            "DangerComposeCompilerMetrics: new file not found at #{File.dirname(__FILE__)}/support/fixtures/compose_compiler_metrics/app_release-classes.txt. Skipping file difference report.",
+            "DangerComposeCompilerMetrics: new file not found at #{File.dirname(__FILE__)}/support/fixtures/compose_compiler_metrics/app_release-classes.txt. Skipping file difference report."
           ]
         )
       end

--- a/spec/compose_compiler_metrics_spec.rb
+++ b/spec/compose_compiler_metrics_spec.rb
@@ -13,12 +13,13 @@ describe Danger::DangerComposeCompilerMetrics do
   end
 
   describe "#report_difference" do
-    subject { plugin.report_difference(metrics_path, reference_metrics_path, options) }
+    subject { plugin.report_difference(metrics_path, reference_metrics_path, options, build_variant_names) }
 
     let(:file_timestamp) { Time.new(2024, 1, 1, 0, 0, 0) }
     let(:metrics_path) { "#{File.dirname(__FILE__)}/support/fixtures/compose_compiler_metrics" }
     let(:reference_metrics_path) { "#{File.dirname(__FILE__)}/support/fixtures/compose_compiler_metrics_baseline" }
     let(:options) { {} }
+    let(:build_variant_names) { nil }
 
     before do
       [
@@ -314,6 +315,36 @@ describe Danger::DangerComposeCompilerMetrics do
 
         expect(dangerfile.status_report[:markdowns][3].message).to eq(
           expect_report_list[3].gsub("<details >", "<details open>")
+        )
+      end
+    end
+
+    context "when build_variant_names is [[app, debug]]" do
+      let(:build_variant_names) { [["app", "debug"]] }
+
+      it do
+        subject
+
+        dangerfile.status_report[:markdowns].map(&:message).each_with_index do |message, index|
+          expect(message).to eq(expect_report_list[index])
+        end
+      end
+    end
+
+    context "when build_variant_names is [[app, release]] that does not exists" do
+      let(:build_variant_names) { [["app", "release"]] }
+
+      it "reports missing report files" do
+        subject
+
+        expect(dangerfile.status_report[:warnings]).to eq(
+          [
+            "DangerComposeCompilerMetrics: new file not found at #{File.dirname(__FILE__)}/support/fixtures/compose_compiler_metrics/app_release-module.json. Skipping file difference report.",
+            "DangerComposeCompilerMetrics: new file not found at #{File.dirname(__FILE__)}/support/fixtures/compose_compiler_metrics/app_release-module.json. Skipping file difference report.",
+            "DangerComposeCompilerMetrics: new file not found at #{File.dirname(__FILE__)}/support/fixtures/compose_compiler_metrics/app_release-composables.csv. Skipping file difference report.",
+            "DangerComposeCompilerMetrics: new file not found at #{File.dirname(__FILE__)}/support/fixtures/compose_compiler_metrics/app_release-composables.txt. Skipping file difference report.",
+            "DangerComposeCompilerMetrics: new file not found at #{File.dirname(__FILE__)}/support/fixtures/compose_compiler_metrics/app_release-classes.txt. Skipping file difference report.",
+          ]
         )
       end
     end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "./lib/compose_compiler_metrics/helper"
+
+describe "Helper" do
+  include Helper
+
+  describe "#build_variants" do
+    subject { build_variants(dir) }
+
+    let(:dir) { Dir.mktmpdir }
+
+    before do
+      build_variants_names.each do |build_variants_name|
+        FileUtils.touch("#{dir}/#{module_name}_#{build_variants_name}-classes.txt")
+        FileUtils.touch("#{dir}/#{module_name}_#{build_variants_name}-composables.csv")
+        FileUtils.touch("#{dir}/#{module_name}_#{build_variants_name}-composables.txt")
+        FileUtils.touch("#{dir}/#{module_name}_#{build_variants_name}-module.json")
+      end
+    end
+
+    after do
+      FileUtils.rm_rf(dir)
+    end
+
+    context "when module name is app" do
+      let(:module_name) { "app" }
+
+      context "when build_variants is debug" do
+        let(:build_variants_names) { ["debug"] }
+
+        it { is_expected.to eq([["app", "debug"]]) }
+      end
+
+      context "when build_variants are debug and release" do
+        let(:build_variants_names) { ["debug", "release"] }
+
+        it { is_expected.to eq([["app", "debug"], ["app", "release"]]) }
+      end
+
+      context "when build_variants is debugProduction" do
+        let(:build_variants_names) { ["debugProduction"] }
+
+        it { is_expected.to eq([["app", "debugProduction"]]) }
+      end
+    end
+
+    context "when module name is app-core" do
+      let(:module_name) { "app-core" }
+
+      context "when build_variants is debug" do
+        let(:build_variants_names) { ["debug"] }
+
+        it { is_expected.to eq([["app-core", "debug"]]) }
+      end
+
+      context "when build_variants is debugProduction" do
+        let(:build_variants_names) { ["debugProduction"] }
+
+        it { is_expected.to eq([["app-core", "debugProduction"]]) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes: https://github.com/tomorrowkey/danger-compose_compiler_metrics/issues/1

Support the module name and build variant that including `-` like `app-core`.
It's going to be detect automatically module name and build variant name.

Support the module name and build variant that including `_` like `app_core`.
It's not going to be detect automatically module name and build variant name.
You can set module name and build variant name to plugin like following.

```ruby
options = {}
build_variant_names = [["app_core", "debug"]]
compose_compiler_metrics.report_difference(report_dir, "#{report_dir}_baseline", options, build_variant_names)
```
